### PR TITLE
Fix flake8 issues and format code

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,5 @@
 """CLI entry point for photo organizer."""
+
 from __future__ import annotations
 
 import argparse
@@ -11,7 +12,9 @@ from photo_organizer.picker import pick_folder
 def main(args: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Photo Organizer CLI")
     parser.add_argument("folder", nargs="?", help="Folder to scan for photos")
-    parser.add_argument("--db", default="photo.db", help="SQLite database path")
+    parser.add_argument(
+        "--db", default="photo.db", help="SQLite database path"
+    )
 
     ns = parser.parse_args(args)
 

--- a/photo_organizer/db.py
+++ b/photo_organizer/db.py
@@ -1,4 +1,5 @@
 """SQLite database utilities for photo organizer."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -22,13 +23,16 @@ def init_db(path: str = "photo.db") -> sqlite3.Connection:
     return conn
 
 
-def insert_metadata(conn: sqlite3.Connection, metadata: Iterable[Dict[str, str]]) -> None:
+def insert_metadata(
+    conn: sqlite3.Connection, metadata: Iterable[Dict[str, str]]
+) -> None:
     """Insert scanned metadata into the database."""
     with conn:
         for entry in metadata:
             conn.execute(
                 "INSERT OR REPLACE INTO photos(path, metadata) VALUES (?, ?)",
-                (entry["path"], json.dumps(entry["exif"]))
+                (entry["path"], json.dumps(entry["exif"])),
             )
+
 
 __all__ = ["init_db", "insert_metadata"]

--- a/photo_organizer/face.py
+++ b/photo_organizer/face.py
@@ -1,4 +1,5 @@
 """Face detection and embedding utilities."""
+
 from __future__ import annotations
 
 import os
@@ -11,7 +12,9 @@ import mediapipe as mp
 
 
 # Initialize MediaPipe face detector
-_mp_face_detection = mp.solutions.face_detection.FaceDetection(model_selection=0, min_detection_confidence=0.5)
+_mp_face_detection = mp.solutions.face_detection.FaceDetection(
+    model_selection=0, min_detection_confidence=0.5
+)
 
 
 class FaceEmbedder:
@@ -19,9 +22,13 @@ class FaceEmbedder:
 
     def __init__(self, model_path: str | None = None) -> None:
         if model_path is None:
-            model_path = os.path.join(os.path.dirname(__file__), "facenet_dummy.onnx")
+            model_path = os.path.join(
+                os.path.dirname(__file__), "facenet_dummy.onnx"
+            )
         try:
-            self.session = ort.InferenceSession(model_path, providers=["CPUExecutionProvider"])
+            self.session = ort.InferenceSession(
+                model_path, providers=["CPUExecutionProvider"]
+            )
             self.input_name = self.session.get_inputs()[0].name
         except Exception:
             self.session = None
@@ -41,6 +48,7 @@ class FaceEmbedder:
 
 
 _embedder: FaceEmbedder | None = None
+
 
 def load_embedder(model_path: str | None = None) -> FaceEmbedder:
     global _embedder
@@ -69,7 +77,9 @@ def detect_faces(img: Image.Image) -> List[Tuple[int, int, int, int]]:
     return boxes
 
 
-def extract_face(img: Image.Image, box: Tuple[int, int, int, int]) -> Image.Image:
+def extract_face(
+    img: Image.Image, box: Tuple[int, int, int, int]
+) -> Image.Image:
     x1, y1, x2, y2 = box
     return img.crop((x1, y1, x2, y2))
 

--- a/photo_organizer/picker.py
+++ b/photo_organizer/picker.py
@@ -1,4 +1,5 @@
 """Folder picker utilities using Tkinter."""
+
 from __future__ import annotations
 
 from tkinter import Tk, filedialog
@@ -13,5 +14,6 @@ def pick_folder() -> str:
     if not folder:
         raise FileNotFoundError("No folder selected")
     return folder
+
 
 __all__ = ["pick_folder"]

--- a/photo_organizer/scan.py
+++ b/photo_organizer/scan.py
@@ -1,4 +1,5 @@
 """Scanning utilities for photo organizer."""
+
 from __future__ import annotations
 
 import os
@@ -8,7 +9,9 @@ from PIL import Image, ExifTags
 from .face import detect_faces, extract_face, load_embedder
 
 
-def _gps_to_decimal(coords: Tuple[Fraction, Fraction, Fraction], ref: str) -> float | None:
+def _gps_to_decimal(
+    coords: Tuple[Fraction, Fraction, Fraction], ref: str
+) -> float | None:
     """Convert GPS coordinates to decimal degrees."""
     try:
         d, m, s = [float(x) for x in coords]
@@ -28,7 +31,10 @@ def _extract_exif(image: Image.Image) -> Dict[str, str]:
     gps_raw = None
     for tag_id, value in info.items():
         tag = ExifTags.TAGS.get(tag_id, tag_id)
-        if tag in {"DateTimeOriginal", "DateTime"} and "timestamp" not in exif_data:
+        if (
+            tag in {"DateTimeOriginal", "DateTime"}
+            and "timestamp" not in exif_data
+        ):
             exif_data["timestamp"] = str(value)
         elif tag == "Make":
             exif_data["camera_make"] = str(value)
@@ -38,7 +44,9 @@ def _extract_exif(image: Image.Image) -> Dict[str, str]:
             gps_raw = value
 
     if gps_raw:
-        gps_parsed = {ExifTags.GPSTAGS.get(k, k): v for k, v in gps_raw.items()}
+        gps_parsed = {
+            ExifTags.GPSTAGS.get(k, k): v for k, v in gps_raw.items()
+        }
         lat = _gps_to_decimal(
             gps_parsed.get("GPSLatitude"), gps_parsed.get("GPSLatitudeRef")
         )
@@ -57,12 +65,17 @@ def _extract_exif(image: Image.Image) -> Dict[str, str]:
     return exif_data
 
 
-def find_images(folder: str, extensions: Iterable[str] | None = None) -> List[str]:
+def find_images(
+    folder: str, extensions: Iterable[str] | None = None
+) -> List[str]:
     """Recursively collect image file paths within *folder*."""
     if extensions is None:
         extensions = {".jpg", ".jpeg", ".png"}
     else:
-        extensions = {e.lower() if e.startswith(".") else f".{e.lower()}" for e in extensions}
+        extensions = {
+            e.lower() if e.startswith(".") else f".{e.lower()}"
+            for e in extensions
+        }
 
     paths: List[str] = []
     for root, _, files in os.walk(folder):
@@ -86,15 +99,18 @@ def scan_folder(folder: str) -> List[Dict[str, str]]:
                 for box in boxes:
                     face_img = extract_face(img, box)
                     embedding = embedder(face_img).astype(float).tolist()
-                    faces_info.append({"box": list(box), "embedding": embedding})
+                    faces_info.append(
+                        {"box": list(box), "embedding": embedding}
+                    )
         except Exception:
             exif = {}
         entry = {
             "path": path,
             "exif": exif,
-             "faces": faces_info,
+            "faces": faces_info,
         }
         metadata.append(entry)
     return metadata
+
 
 __all__ = ["scan_folder", "find_images"]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,10 +1,11 @@
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import json
-from PIL import Image
-from photo_organizer.db import init_db, insert_metadata
+import json  # noqa: E402
+from PIL import Image  # noqa: E402
+from photo_organizer.db import init_db, insert_metadata  # noqa: E402
 
 
 def test_insert_and_retrieve_metadata(tmp_path):
@@ -13,7 +14,9 @@ def test_insert_and_retrieve_metadata(tmp_path):
     entry = {"path": str(img_path), "exif": {"key": "value"}}
     conn = init_db(str(tmp_path / "photo.db"))
     insert_metadata(conn, [entry])
-    row = conn.execute("SELECT metadata FROM photos WHERE path=?", (str(img_path),)).fetchone()
+    row = conn.execute(
+        "SELECT metadata FROM photos WHERE path=?", (str(img_path),)
+    ).fetchone()
     assert row is not None
     meta = json.loads(row[0])
     assert meta == entry["exif"]

--- a/tests/test_face.py
+++ b/tests/test_face.py
@@ -1,16 +1,21 @@
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from PIL import Image
-from photo_organizer.face import detect_faces, extract_face, load_embedder
+from PIL import Image  # noqa: E402
+from photo_organizer.face import (  # noqa: E402
+    detect_faces,
+    extract_face,
+    load_embedder,
+)
 
 
 def test_detect_and_embed():
     # Create a simple blank image instead of loading one from disk
     img = Image.new("RGB", (10, 10))
     boxes = detect_faces(img)
-    assert boxes, 'no face detected'
+    assert boxes, "no face detected"
     face_img = extract_face(img, boxes[0])
     embedder = load_embedder()
     emb = embedder(face_img)

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,9 +1,10 @@
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from photo_organizer.scan import scan_folder
-from PIL import Image
+from photo_organizer.scan import scan_folder  # noqa: E402
+from PIL import Image  # noqa: E402
 
 
 def test_scan_folder(tmp_path):


### PR DESCRIPTION
## Summary
- run `black --line-length 79` to reformat CLI, library and tests
- clean up blank lines and long strings
- adjust tests to keep `sys.path` modification while appeasing flake8

## Testing
- `flake8 cli.py photo_organizer tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652c4a1efc8329bb6b25c14a4d2bba