### PR TITLE
Add tests for database functions and CLI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,15 @@
+from PIL import Image
+from cli import main
+from photo_organizer.db import init_db
+
+
+def test_cli_main(tmp_path):
+    img = Image.new("RGB", (5, 5))
+    img_path = tmp_path / "img.jpg"
+    img.save(img_path)
+    db_path = tmp_path / "photo.db"
+    ret = main([str(tmp_path), "--db", str(db_path)])
+    assert ret == 0
+    conn = init_db(str(db_path))
+    count = conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+    assert count == 1


### PR DESCRIPTION
## Summary
- add tests for init_db and insert_metadata
- add CLI test using a temporary folder

## Testing
- `pycodestyle cli.py photo_organizer tests | head -n 20`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865378512808329839ecac840a9c3ff