### PR TITLE
Add face clustering and update DB storage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from photo_organizer.scan import scan_folder
+from photo_organizer.cluster import cluster_faces
 from photo_organizer.db import init_db, insert_metadata
 from photo_organizer.picker import pick_folder
 
@@ -21,6 +22,7 @@ def main(args: list[str] | None = None) -> int:
     folder = ns.folder or pick_folder()
     print(f"Scanning {folder}...")
     metadata = scan_folder(folder)
+    cluster_faces(metadata)
     conn = init_db(ns.db)
     insert_metadata(conn, metadata)
     print(f"Inserted {len(metadata)} records into {ns.db}")

--- a/photo_organizer/__init__.py
+++ b/photo_organizer/__init__.py
@@ -2,6 +2,6 @@
 
 __version__ = "0.1.0"
 
-from . import scan, db, picker
+from . import scan, db, picker, cluster
 
-__all__ = ["scan", "db", "picker", "__version__"]
+__all__ = ["scan", "db", "picker", "cluster", "__version__"]

--- a/photo_organizer/cluster.py
+++ b/photo_organizer/cluster.py
@@ -8,7 +8,11 @@ import numpy as np
 from sklearn.cluster import DBSCAN
 
 
-def cluster_faces(metadata: List[Dict[str, Any]], eps: float = 0.5, min_samples: int = 3) -> List[Dict[str, Any]]:
+def cluster_faces(
+    metadata: List[Dict[str, Any]],
+    eps: float = 0.5,
+    min_samples: int = 3,
+) -> List[Dict[str, Any]]:
     """Assign cluster labels to faces across *metadata*.
 
     This iterates over all face embeddings, performs DBSCAN clustering,

--- a/photo_organizer/cluster.py
+++ b/photo_organizer/cluster.py
@@ -1,0 +1,34 @@
+"""Face clustering utilities."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+import numpy as np
+from sklearn.cluster import DBSCAN
+
+
+def cluster_faces(metadata: List[Dict[str, Any]], eps: float = 0.5, min_samples: int = 3) -> List[Dict[str, Any]]:
+    """Assign cluster labels to faces across *metadata*.
+
+    This iterates over all face embeddings, performs DBSCAN clustering,
+    and sets ``face["cluster_id"]`` for each face dictionary. The function
+    returns the input list for convenience.
+    """
+    embeddings: List[List[float]] = []
+    faces: List[Dict[str, Any]] = []
+    for entry in metadata:
+        for face in entry.get("faces", []):
+            if "embedding" in face:
+                embeddings.append(face["embedding"])
+                faces.append(face)
+
+    if embeddings:
+        arr = np.array(embeddings)
+        labels = DBSCAN(eps=eps, min_samples=min_samples).fit(arr).labels_
+        for face, label in zip(faces, labels):
+            face["cluster_id"] = int(label)
+    return metadata
+
+
+__all__ = ["cluster_faces"]

--- a/photo_organizer/db.py
+++ b/photo_organizer/db.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 import json
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Any
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS photos (
@@ -24,14 +24,14 @@ def init_db(path: str = "photo.db") -> sqlite3.Connection:
 
 
 def insert_metadata(
-    conn: sqlite3.Connection, metadata: Iterable[Dict[str, str]]
+    conn: sqlite3.Connection, metadata: Iterable[Dict[str, Any]]
 ) -> None:
     """Insert scanned metadata into the database."""
     with conn:
         for entry in metadata:
             conn.execute(
                 "INSERT OR REPLACE INTO photos(path, metadata) VALUES (?, ?)",
-                (entry["path"], json.dumps(entry["exif"])),
+                (entry["path"], json.dumps(entry)),
             )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "mediapipe",
     "onnxruntime",
     "numpy",
+    "scikit-learn",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Pillow
 mediapipe
 onnxruntime
 numpy
+scikit-learn

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from PIL import Image
+import json
 from cli import main
 from photo_organizer.db import init_db
 
@@ -11,5 +12,8 @@ def test_cli_main(tmp_path):
     ret = main([str(tmp_path), "--db", str(db_path)])
     assert ret == 0
     conn = init_db(str(db_path))
-    count = conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
-    assert count == 1
+    row = conn.execute("SELECT metadata FROM photos").fetchone()
+    assert row is not None
+    meta = json.loads(row[0])
+    assert meta["faces"]
+    assert "cluster_id" in meta["faces"][0]

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,0 +1,27 @@
+from photo_organizer.cluster import cluster_faces
+
+
+def test_cluster_faces_assigns_ids():
+    meta = [
+        {
+            "path": "a.jpg",
+            "exif": {},
+            "faces": [
+                {"embedding": [0.0] * 128},
+                {"embedding": [0.0] * 128},
+            ],
+        },
+        {
+            "path": "b.jpg",
+            "exif": {},
+            "faces": [
+                {"embedding": [1.0] * 128},
+            ],
+        },
+    ]
+    result = cluster_faces(meta, eps=1.0, min_samples=1)
+    for entry in result:
+        for face in entry["faces"]:
+            assert "cluster_id" in face
+            assert isinstance(face["cluster_id"], int)
+

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -24,4 +24,3 @@ def test_cluster_faces_assigns_ids():
         for face in entry["faces"]:
             assert "cluster_id" in face
             assert isinstance(face["cluster_id"], int)
-

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,7 +6,11 @@ from photo_organizer.db import init_db, insert_metadata
 def test_insert_and_retrieve_metadata(tmp_path):
     img_path = tmp_path / "img.jpg"
     Image.new("RGB", (5, 5)).save(img_path)
-    entry = {"path": str(img_path), "exif": {"key": "value"}}
+    entry = {
+        "path": str(img_path),
+        "exif": {"key": "value"},
+        "faces": [],
+    }
     conn = init_db(str(tmp_path / "photo.db"))
     insert_metadata(conn, [entry])
     row = conn.execute(
@@ -14,7 +18,7 @@ def test_insert_and_retrieve_metadata(tmp_path):
     ).fetchone()
     assert row is not None
     meta = json.loads(row[0])
-    assert meta == entry["exif"]
+    assert meta == entry
 
 
 def test_init_db_creates_table(tmp_path):
@@ -35,8 +39,8 @@ def test_insert_metadata_multiple(tmp_path):
     db_file = tmp_path / "db.sqlite"
     conn = init_db(str(db_file))
     entries = [
-        {"path": str(img1), "exif": {"n": "1"}},
-        {"path": str(img2), "exif": {"n": "2"}},
+        {"path": str(img1), "exif": {"n": "1"}, "faces": []},
+        {"path": str(img2), "exif": {"n": "2"}, "faces": []},
     ]
     insert_metadata(conn, entries)
     rows = list(conn.execute("SELECT path FROM photos ORDER BY path"))


### PR DESCRIPTION
## Summary
- implement `cluster_faces` utility using DBSCAN
- update CLI to cluster faces before saving
- store full metadata JSON in the database
- include new clustering tests
- add scikit-learn dependency

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654699d010832992a3b24a956001a4