### PR TITLE
Add classifier tests and verify category strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -3,38 +3,50 @@ from photo_organizer import classifier
 
 ALLOWED = {"selfie", "document", "screenshot", "nature", "other"}
 
+
 def _patch_dummy_classifier(monkeypatch, label="person"):
     class DummyTensor:
+
         def unsqueeze(self, dim):
             return self
 
     class DummyLogits:
+
         def argmax(self, dim):
             class Res:
+
                 def __init__(self, val):
                     self._val = val
+
                 def item(self):
                     return self._val
+
             return Res(0)
 
     class DummyCtx:
+
         def __enter__(self):
             pass
+
         def __exit__(self, exc_type, exc, tb):
             pass
 
     class DummyTorch:
+
         def no_grad(self):
             return DummyCtx()
 
     class DummyWeights:
+
         DEFAULT = type("DW", (), {"meta": {"categories": [label]}})
 
     monkeypatch.setattr(classifier, "_classifier", lambda t: DummyLogits())
     monkeypatch.setattr(classifier, "_transform", lambda img: DummyTensor())
     monkeypatch.setattr(classifier, "transforms", object(), raising=False)
     monkeypatch.setattr(classifier, "torch", DummyTorch(), raising=False)
-    monkeypatch.setattr(classifier, "MobileNet_V2_Weights", DummyWeights, raising=False)
+    monkeypatch.setattr(
+        classifier, "MobileNet_V2_Weights", DummyWeights, raising=False
+    )
     monkeypatch.setattr(classifier, "load_classifier", lambda: None)
 
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,56 @@
+from PIL import Image
+from photo_organizer import classifier
+
+ALLOWED = {"selfie", "document", "screenshot", "nature", "other"}
+
+def _patch_dummy_classifier(monkeypatch, label="person"):
+    class DummyTensor:
+        def unsqueeze(self, dim):
+            return self
+
+    class DummyLogits:
+        def argmax(self, dim):
+            class Res:
+                def __init__(self, val):
+                    self._val = val
+                def item(self):
+                    return self._val
+            return Res(0)
+
+    class DummyCtx:
+        def __enter__(self):
+            pass
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class DummyTorch:
+        def no_grad(self):
+            return DummyCtx()
+
+    class DummyWeights:
+        DEFAULT = type("DW", (), {"meta": {"categories": [label]}})
+
+    monkeypatch.setattr(classifier, "_classifier", lambda t: DummyLogits())
+    monkeypatch.setattr(classifier, "_transform", lambda img: DummyTensor())
+    monkeypatch.setattr(classifier, "transforms", object(), raising=False)
+    monkeypatch.setattr(classifier, "torch", DummyTorch(), raising=False)
+    monkeypatch.setattr(classifier, "MobileNet_V2_Weights", DummyWeights, raising=False)
+    monkeypatch.setattr(classifier, "load_classifier", lambda: None)
+
+
+def test_classify_image_green_is_nature(monkeypatch):
+    monkeypatch.setattr(classifier, "_classifier", None)
+    monkeypatch.setattr(classifier, "_transform", None)
+    monkeypatch.setattr(classifier, "load_classifier", lambda: None)
+    img = Image.new("RGB", (10, 10), (0, 255, 0))
+    cat = classifier.classify_image(img)
+    assert cat == "nature"
+    assert cat in ALLOWED
+
+
+def test_classify_image_stubbed_selfie(monkeypatch):
+    _patch_dummy_classifier(monkeypatch, label="person")
+    img = Image.new("RGB", (5, 5))
+    cat = classifier.classify_image(img)
+    assert cat == "selfie"
+    assert cat in ALLOWED

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@ import json
 from cli import main
 from photo_organizer.db import init_db
 
+ALLOWED = {"selfie", "document", "screenshot", "nature", "other"}
+
 
 def test_cli_main(tmp_path):
     img = Image.new("RGB", (5, 5))
@@ -19,3 +21,4 @@ def test_cli_main(tmp_path):
     assert "cluster_id" in meta["faces"][0]
     assert "category" in meta
     assert isinstance(meta["category"], str)
+    assert meta["category"] in ALLOWED

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,6 +1,8 @@
 from PIL import Image
 from photo_organizer.scan import scan_folder, find_images, _extract_exif
 
+ALLOWED = {"selfie", "document", "screenshot", "nature", "other"}
+
 
 def test_scan_folder(tmp_path):
     img_path = tmp_path / "image.jpg"
@@ -14,6 +16,7 @@ def test_scan_folder(tmp_path):
     assert isinstance(metadata[0]["faces"], list)
     assert "category" in metadata[0]
     assert isinstance(metadata[0]["category"], str)
+    assert metadata[0]["category"] in ALLOWED
 
 
 def test_extract_exif_invalid_gps():


### PR DESCRIPTION
## Summary
- add a test suite for `classify_image`
- validate category values in CLI and scan tests
- ignore Python cache files in repo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655a00d2c8832990fae315f0768c4a