### PR TITLE
Add Tesseract OCR extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Run the scanner:
 python cli.py /path/to/photos --db photo.db
 ```
 The resulting metadata stored in the database includes a `category` field for
-each image describing its type.
+each image describing its type. If an image is classified as a document or ID,
+the text content is extracted using Tesseract (when available) and stored under
+the `ocr_text` key.
 
 ## Testing
 

--- a/photo_organizer/__init__.py
+++ b/photo_organizer/__init__.py
@@ -2,6 +2,14 @@
 
 __version__ = "0.1.0"
 
-from . import scan, db, picker, cluster, classifier
+from . import scan, db, picker, cluster, classifier, ocr
 
-__all__ = ["scan", "db", "picker", "cluster", "classifier", "__version__"]
+__all__ = [
+    "scan",
+    "db",
+    "picker",
+    "cluster",
+    "classifier",
+    "ocr",
+    "__version__",
+]

--- a/photo_organizer/ocr.py
+++ b/photo_organizer/ocr.py
@@ -1,0 +1,23 @@
+"""OCR utilities for document images."""
+
+from __future__ import annotations
+
+from PIL import Image
+
+try:  # pragma: no cover - optional dependency
+    import pytesseract
+except Exception:  # pragma: no cover - handled gracefully
+    pytesseract = None  # type: ignore
+
+
+def extract_text(img: Image.Image) -> str:
+    """Return text from *img* using Tesseract if available."""
+    if pytesseract is None:
+        return ""
+    try:  # pragma: no cover - runtime OCR
+        return pytesseract.image_to_string(img)
+    except Exception:
+        return ""
+
+
+__all__ = ["extract_text"]

--- a/photo_organizer/scan.py
+++ b/photo_organizer/scan.py
@@ -8,6 +8,7 @@ from typing import Dict, Iterable, List, Tuple
 from PIL import Image, ExifTags
 from .face import detect_faces, extract_face, load_embedder
 from .classifier import classify_image
+from .ocr import extract_text
 
 
 def _gps_to_decimal(
@@ -94,10 +95,13 @@ def scan_folder(folder: str) -> List[Dict[str, str]]:
     for path in find_images(folder):
         faces_info = []
         category = "other"
+        text = ""
         try:
             with Image.open(path) as img:
                 exif = _extract_exif(img)
                 category = classify_image(img)
+                if category in {"document", "id"}:
+                    text = extract_text(img)
                 boxes = detect_faces(img)
                 for box in boxes:
                     face_img = extract_face(img, box)
@@ -112,6 +116,7 @@ def scan_folder(folder: str) -> List[Dict[str, str]]:
             "exif": exif,
             "faces": faces_info,
             "category": category,
+            "ocr_text": text,
         }
         metadata.append(entry)
     return metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "scikit-learn",
     "torch",
     "torchvision",
+    "pytesseract",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 scikit-learn
 torch
 torchvision
+pytesseract

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,17 @@
+from PIL import Image
+from photo_organizer.scan import scan_folder
+
+
+def test_ocr_text_extraction(monkeypatch, tmp_path):
+    img_path = tmp_path / "doc.jpg"
+    Image.new("RGB", (10, 10)).save(img_path)
+
+    monkeypatch.setattr(
+        "photo_organizer.classifier.classify_image", lambda img: "document"
+    )
+    monkeypatch.setattr(
+        "photo_organizer.ocr.extract_text", lambda img: "hello"
+    )
+
+    meta = scan_folder(str(tmp_path))
+    assert meta[0]["ocr_text"] == "hello"

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -17,6 +17,7 @@ def test_scan_folder(tmp_path):
     assert "category" in metadata[0]
     assert isinstance(metadata[0]["category"], str)
     assert metadata[0]["category"] in ALLOWED
+    assert "ocr_text" in metadata[0]
 
 
 def test_extract_exif_invalid_gps():


### PR DESCRIPTION
## Summary
- extract text using pytesseract
- expose ocr module via package init
- run OCR when images are classified as documents or IDs
- record OCR text in scan metadata
- document new OCR capability
- add pytesseract dependency
- test OCR extraction logic

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68655d7238d883298d25bab2ed2c6bdd