### PR TITLE
Update README with tesseract instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
+OCR features require the system `tesseract` executable. Install it with:
+
+```bash
+sudo apt-get install tesseract-ocr  # Ubuntu
+brew install tesseract              # macOS (Homebrew)
+```
+
 Run the scanner:
 
 ```bash


### PR DESCRIPTION
## Summary
- document tesseract requirement in README

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6865797770f88329b8291ccce4d510ca