### PR TITLE
Add grouping option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Run the scanner:
 ```bash
 python cli.py /path/to/photos --db photo.db
 ```
+To group photos by location, pass `--group-by` with a level such as `city`:
+
+```bash
+python cli.py /path/to/photos --db photo.db --group-by city
+```
 The resulting metadata stored in the database includes a `category` field for
 each image describing its type. If an image is classified as a document or ID,
 the text content is extracted using Tesseract (when available) and stored under

--- a/cli.py
+++ b/cli.py
@@ -8,6 +8,8 @@ from photo_organizer.scan import scan_folder
 from photo_organizer.cluster import cluster_faces
 from photo_organizer.db import init_db, insert_metadata
 from photo_organizer.picker import pick_folder
+from photo_organizer.location import group_by_location
+import json
 
 
 def main(args: list[str] | None = None) -> int:
@@ -15,6 +17,11 @@ def main(args: list[str] | None = None) -> int:
     parser.add_argument("folder", nargs="?", help="Folder to scan for photos")
     parser.add_argument(
         "--db", default="photo.db", help="SQLite database path"
+    )
+    parser.add_argument(
+        "--group-by",
+        choices=["city", "state", "country"],
+        help="Group results by location level",
     )
 
     ns = parser.parse_args(args)
@@ -27,6 +34,9 @@ def main(args: list[str] | None = None) -> int:
     for entry in metadata:
         entry.setdefault("category", "other")
     cluster_faces(metadata)
+    if ns.group_by:
+        groups = group_by_location(metadata, level=ns.group_by)
+        print(json.dumps(groups))
     conn = init_db(ns.db)
     insert_metadata(conn, metadata)
     print(f"Inserted {len(metadata)} records into {ns.db}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,8 +45,7 @@ def test_cli_group_by(monkeypatch, tmp_path, capsys):
     ret = main([str(tmp_path), "--db", str(db_path), "--group-by", "city"])
     assert ret == 0
     out = capsys.readouterr().out
-    json_line = [l for l in out.splitlines() if l.startswith("{")][0]
+    json_line = [line for line in out.splitlines() if line.startswith("{")][0]
     groups = json.loads(json_line)
     assert "TestCity" in groups
     assert groups["TestCity"][0]["city"] == "TestCity"
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,3 +22,31 @@ def test_cli_main(tmp_path):
     assert "category" in meta
     assert isinstance(meta["category"], str)
     assert meta["category"] in ALLOWED
+
+
+def test_cli_group_by(monkeypatch, tmp_path, capsys):
+    img = Image.new("RGB", (5, 5))
+    img_path = tmp_path / "img.jpg"
+    img.save(img_path)
+    db_path = tmp_path / "photo.db"
+
+    monkeypatch.setattr(
+        "photo_organizer.scan._extract_exif", lambda img: {"gps": "0,0"}
+    )
+    monkeypatch.setattr(
+        "photo_organizer.scan.resolve_location",
+        lambda lat, lon: {
+            "city": "TestCity",
+            "state": "TestState",
+            "country": "TestCountry",
+        },
+    )
+
+    ret = main([str(tmp_path), "--db", str(db_path), "--group-by", "city"])
+    assert ret == 0
+    out = capsys.readouterr().out
+    json_line = [l for l in out.splitlines() if l.startswith("{")][0]
+    groups = json.loads(json_line)
+    assert "TestCity" in groups
+    assert groups["TestCity"][0]["city"] == "TestCity"
+


### PR DESCRIPTION
## Summary
- implement `--group-by` option in `cli.py`
- demonstrate grouping usage in README
- test grouping behavior with stubbed location resolution

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686811c712108329ae9c83a1a9428c1c