### PR TITLE
Add event grouping utilities

### DIFF
--- a/photo_organizer/__init__.py
+++ b/photo_organizer/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "0.1.0"
 
-from . import scan, db, picker, cluster, classifier, ocr, location
+from . import scan, db, picker, cluster, classifier, ocr, location, events
 
 __all__ = [
     "scan",
@@ -12,5 +12,6 @@ __all__ = [
     "classifier",
     "ocr",
     "location",
+    "events",
     "__version__",
 ]

--- a/photo_organizer/events.py
+++ b/photo_organizer/events.py
@@ -1,0 +1,60 @@
+"""Event grouping utilities for photo organizer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, Iterable, List, Any
+
+
+def group_by_event(
+    metadata: Iterable[Dict[str, Any]], gap_hours: int = 6
+) -> Dict[int, List[Dict[str, Any]]]:
+    """Group metadata entries into events separated by *gap_hours*.
+
+    Each entry must have ``entry["exif"]["timestamp"]`` in the format
+    ``YYYY:MM:DD HH:MM:SS``. Entries are sorted by this timestamp and a new
+    event is started whenever the time gap between consecutive photos exceeds
+    ``gap_hours``. The ``event_id`` field is added to each entry. The returned
+    dictionary maps event IDs to the corresponding list of entries.
+    """
+    items: List[tuple[datetime, Dict[str, Any]]] = []
+    for entry in metadata:
+        ts_str = entry.get("exif", {}).get("timestamp")
+        if ts_str is None:
+            continue
+        try:
+            dt = datetime.strptime(ts_str, "%Y:%m:%d %H:%M:%S")
+        except Exception:
+            continue
+        items.append((dt, entry))
+
+    items.sort(key=lambda x: x[0])
+
+    events: Dict[int, List[Dict[str, Any]]] = {}
+    last_dt: datetime | None = None
+    event_id = 0
+    for dt, entry in items:
+        if last_dt is None or dt - last_dt > timedelta(hours=gap_hours):
+            event_id = len(events)
+            events[event_id] = []
+        entry["event_id"] = event_id
+        events[event_id].append(entry)
+        last_dt = dt
+
+    return events
+
+
+def name_event(event_map: Dict[int, List[Dict[str, Any]]], event_id: int, name: str) -> None:
+    """Assign a human-friendly *name* to an event."""
+    for entry in event_map.get(event_id, []):
+        entry["event_name"] = name
+
+
+def rename_event(
+    event_map: Dict[int, List[Dict[str, Any]]], event_id: int, new_name: str
+) -> None:
+    """Change the human-friendly name for an event."""
+    name_event(event_map, event_id, new_name)
+
+
+__all__ = ["group_by_event", "name_event", "rename_event"]

--- a/photo_organizer/events.py
+++ b/photo_organizer/events.py
@@ -44,7 +44,11 @@ def group_by_event(
     return events
 
 
-def name_event(event_map: Dict[int, List[Dict[str, Any]]], event_id: int, name: str) -> None:
+def name_event(
+    event_map: Dict[int, List[Dict[str, Any]]],
+    event_id: int,
+    name: str,
+) -> None:
     """Assign a human-friendly *name* to an event."""
     for entry in event_map.get(event_id, []):
         entry["event_name"] = name

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,45 @@
+from photo_organizer.events import group_by_event, name_event, rename_event
+
+
+def test_group_by_event_assigns_ids_and_groups():
+    metadata = [
+        {
+            "path": "a.jpg",
+            "exif": {"timestamp": "2023:01:01 10:00:00"},
+            "faces": [],
+            "category": "other",
+        },
+        {
+            "path": "b.jpg",
+            "exif": {"timestamp": "2023:01:01 12:00:00"},
+            "faces": [],
+            "category": "other",
+        },
+        {
+            "path": "c.jpg",
+            "exif": {"timestamp": "2023:01:02 00:00:00"},
+            "faces": [],
+            "category": "other",
+        },
+    ]
+
+    events = group_by_event(metadata, gap_hours=6)
+    assert set(events.keys()) == {0, 1}
+    assert [e["event_id"] for e in events[0]] == [0, 0]
+    assert [e["event_id"] for e in events[1]] == [1]
+
+
+def test_name_and_rename_event():
+    metadata = [
+        {
+            "path": "a.jpg",
+            "exif": {"timestamp": "2023:01:01 10:00:00"},
+            "faces": [],
+            "category": "other",
+        }
+    ]
+    events = group_by_event(metadata)
+    name_event(events, 0, "Birthday")
+    assert events[0][0]["event_name"] == "Birthday"
+    rename_event(events, 0, "Party")
+    assert events[0][0]["event_name"] == "Party"


### PR DESCRIPTION
## Summary
- implement `photo_organizer.events` with helpers for grouping photos into events
- export new module in package `__all__`
- test event grouping and naming

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729741fce88329ab7b2f3ec6aba72a