### PR TITLE
Add event grouping option to CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,6 +9,7 @@ from photo_organizer.cluster import cluster_faces
 from photo_organizer.db import init_db, insert_metadata
 from photo_organizer.picker import pick_folder
 from photo_organizer.location import group_by_location
+from photo_organizer.events import group_by_event
 import json
 
 
@@ -23,6 +24,15 @@ def main(args: list[str] | None = None) -> int:
         choices=["city", "state", "country"],
         help="Group results by location level",
     )
+    parser.add_argument(
+        "--group-events",
+        nargs="?",
+        const=6,
+        default=None,
+        type=int,
+        metavar="HOURS",
+        help="Group photos into events separated by HOURS gap (default: 6)",
+    )
 
     ns = parser.parse_args(args)
 
@@ -34,6 +44,9 @@ def main(args: list[str] | None = None) -> int:
     for entry in metadata:
         entry.setdefault("category", "other")
     cluster_faces(metadata)
+    if ns.group_events is not None:
+        event_groups = group_by_event(metadata, gap_hours=ns.group_events)
+        print(json.dumps(event_groups))
     if ns.group_by:
         groups = group_by_location(metadata, level=ns.group_by)
         print(json.dumps(groups))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,3 +49,30 @@ def test_cli_group_by(monkeypatch, tmp_path, capsys):
     groups = json.loads(json_line)
     assert "TestCity" in groups
     assert groups["TestCity"][0]["city"] == "TestCity"
+
+
+def test_cli_group_events(monkeypatch, tmp_path, capsys):
+    img1 = tmp_path / "a.jpg"
+    img2 = tmp_path / "b.jpg"
+    Image.new("RGB", (5, 5)).save(img1)
+    Image.new("RGB", (5, 5)).save(img2)
+    db_path = tmp_path / "photo.db"
+
+    timestamps = ["2023:01:01 10:00:00", "2023:01:02 00:00:00"]
+
+    def fake_exif(img):
+        return {"timestamp": timestamps.pop(0)}
+
+    monkeypatch.setattr("photo_organizer.scan._extract_exif", fake_exif)
+
+    ret = main([str(tmp_path), "--db", str(db_path), "--group-events"])
+    assert ret == 0
+    out = capsys.readouterr().out
+    json_line = [line for line in out.splitlines() if line.startswith("{")][0]
+    groups = json.loads(json_line)
+    assert set(groups.keys()) == {"0", "1"}
+
+    conn = init_db(str(db_path))
+    rows = conn.execute("SELECT metadata FROM photos").fetchall()
+    event_ids = {json.loads(r[0])["event_id"] for r in rows}
+    assert event_ids == {0, 1}


### PR DESCRIPTION
## Summary
- add `--group-events` option to CLI for grouping photos by event
- invoke event grouping before inserting to DB and print JSON summary
- test new CLI option to ensure event IDs saved

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729d7b2c248329979a4d692bba888e