### PR TITLE
Add extra event grouping tests

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,27 +1,22 @@
 from photo_organizer.events import group_by_event, name_event, rename_event
 
 
-def test_group_by_event_assigns_ids_and_groups():
-    metadata = [
+def _make_metadata(ts_list):
+    return [
         {
-            "path": "a.jpg",
-            "exif": {"timestamp": "2023:01:01 10:00:00"},
+            "path": f"img{i}.jpg",
+            "exif": {"timestamp": ts},
             "faces": [],
             "category": "other",
-        },
-        {
-            "path": "b.jpg",
-            "exif": {"timestamp": "2023:01:01 12:00:00"},
-            "faces": [],
-            "category": "other",
-        },
-        {
-            "path": "c.jpg",
-            "exif": {"timestamp": "2023:01:02 00:00:00"},
-            "faces": [],
-            "category": "other",
-        },
+        }
+        for i, ts in enumerate(ts_list)
     ]
+
+
+def test_group_by_event_assigns_ids_and_groups():
+    metadata = _make_metadata(
+        ["2023:01:01 10:00:00", "2023:01:01 12:00:00", "2023:01:02 00:00:00"]
+    )
 
     events = group_by_event(metadata, gap_hours=6)
     assert set(events.keys()) == {0, 1}
@@ -43,3 +38,23 @@ def test_name_and_rename_event():
     assert events[0][0]["event_name"] == "Birthday"
     rename_event(events, 0, "Party")
     assert events[0][0]["event_name"] == "Party"
+
+
+def test_group_by_event_gap_threshold():
+    timestamps = [
+        "2023:01:01 00:00:00",
+        "2023:01:01 01:00:00",
+        "2023:01:01 02:30:00",
+        "2023:01:01 10:00:00",
+        "2023:01:01 10:30:00",
+    ]
+    metadata = _make_metadata(timestamps)
+
+    events = group_by_event(metadata, gap_hours=2)
+    assert list(events.keys()) == [0, 1]
+    assert [e["event_id"] for e in events[0]] == [0, 0, 0]
+    assert [e["event_id"] for e in events[1]] == [1, 1]
+
+    events = group_by_event(metadata, gap_hours=8)
+    assert list(events.keys()) == [0]
+    assert [e["event_id"] for e in events[0]] == [0] * 5


### PR DESCRIPTION
## Summary
- expand the event tests to cover threshold behavior and rename logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a249cdf483298097d08dab436956