### PR TITLE
Add basic Electron+React UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ __pycache__/
 *.pyc
 *.pyo
 .pytest_cache/
+# Node
+ui/node_modules/
+ui/dist/
+photo_organizer.egg-info/

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Photo Organizer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/ui/main.js
+++ b/ui/main.js
@@ -1,0 +1,46 @@
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const path = require('node:path');
+const { spawn } = require('child_process');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1000,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  const devUrl = process.env.VITE_DEV_SERVER_URL;
+  if (process.env.NODE_ENV === 'development' && devUrl) {
+    win.loadURL(devUrl);
+    win.webContents.openDevTools();
+  } else {
+    win.loadFile(path.join(__dirname, 'dist/index.html'));
+  }
+}
+
+app.whenReady().then(createWindow);
+
+ipcMain.handle('select-folder', async () => {
+  const { canceled, filePaths } = await dialog.showOpenDialog({
+    properties: ['openDirectory'],
+  });
+  if (canceled) return null;
+  return filePaths[0];
+});
+
+ipcMain.handle('scan-folder', async (_evt, folder) => {
+  return new Promise((resolve) => {
+    const script = path.join(__dirname, '..', 'cli.py');
+    const child = spawn('python', [script, folder]);
+    let output = '';
+    child.stdout.on('data', (d) => (output += d));
+    child.stderr.on('data', (d) => console.error(d.toString()));
+    child.on('close', () => resolve(output));
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "photo-organizer-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "main.js",
+  "scripts": {
+    "dev": "concurrently -k \"vite\" \"cross-env NODE_ENV=development VITE_DEV_SERVER_URL=http://localhost:5173 electron .\"",
+    "build": "vite build",
+    "start": "electron ."
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.1.0",
+    "vite": "^5.2.0",
+    "electron": "^28.2.0",
+    "concurrently": "^8.2.0",
+    "cross-env": "^7.0.3"
+  }
+}

--- a/ui/preload.js
+++ b/ui/preload.js
@@ -1,0 +1,6 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  selectFolder: () => ipcRenderer.invoke('select-folder'),
+  scanFolder: (folder) => ipcRenderer.invoke('scan-folder', folder),
+});

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import Sidebar from './components/Sidebar';
+import ImageGrid from './components/ImageGrid';
+
+function App() {
+  const [folder, setFolder] = useState(null);
+  const [images, setImages] = useState([]);
+
+  const handleSelectFolder = async () => {
+    const selected = await window.electronAPI.selectFolder();
+    if (!selected) return;
+    setFolder(selected);
+    const output = await window.electronAPI.scanFolder(selected);
+    try {
+      const data = JSON.parse(output);
+      setImages(data.map((entry) => entry.path));
+    } catch (err) {
+      console.error('Failed to parse CLI output', err, output);
+    }
+  };
+
+  return (
+    <div className="app">
+      <Sidebar onSelectFolder={handleSelectFolder} folder={folder} />
+      <ImageGrid images={images} />
+    </div>
+  );
+}
+
+export default App;

--- a/ui/src/components/ImageGrid.jsx
+++ b/ui/src/components/ImageGrid.jsx
@@ -1,0 +1,11 @@
+function ImageGrid({ images }) {
+  return (
+    <div className="grid">
+      {images.map((img, i) => (
+        <img key={i} src={`file://${img}`} alt="" />
+      ))}
+    </div>
+  );
+}
+
+export default ImageGrid;

--- a/ui/src/components/Sidebar.jsx
+++ b/ui/src/components/Sidebar.jsx
@@ -1,0 +1,10 @@
+function Sidebar({ onSelectFolder, folder }) {
+  return (
+    <div className="sidebar">
+      <button onClick={onSelectFolder}>Choose Folder</button>
+      {folder && <p>{folder}</p>}
+    </div>
+  );
+}
+
+export default Sidebar;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,18 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+.sidebar {
+  padding: 1rem;
+  background-color: #f0f0f0;
+}
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+}
+.grid img {
+  width: 150px;
+  height: 150px;
+  object-fit: cover;
+  margin: 4px;
+}

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- set up an Electron app with Vite and React in `ui/`
- add Electron `main.js` and preload script
- create simple React components for folder selection and image display
- ignore Node build artifacts

## Testing
- `pip install -r dev-requirements.txt`
- `pip install -e . --no-deps`
- `pip install onnxruntime`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6872b01d62c48329ae67ebb272db8a68