### PR TITLE
Ensure CLI prints JSON by default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -47,9 +47,11 @@ def main(args: list[str] | None = None) -> int:
     if ns.group_events is not None:
         event_groups = group_by_event(metadata, gap_hours=ns.group_events)
         print(json.dumps(event_groups))
-    if ns.group_by:
+    elif ns.group_by:
         groups = group_by_location(metadata, level=ns.group_by)
         print(json.dumps(groups))
+    else:
+        print(json.dumps(metadata))
     conn = init_db(ns.db)
     insert_metadata(conn, metadata)
     print(f"Inserted {len(metadata)} records into {ns.db}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,21 @@ def test_cli_main(tmp_path):
     assert meta["category"] in ALLOWED
 
 
+def test_cli_default_json_output(tmp_path, capsys):
+    img = Image.new("RGB", (5, 5))
+    img_path = tmp_path / "img.jpg"
+    img.save(img_path)
+    db_path = tmp_path / "photo.db"
+
+    ret = main([str(tmp_path), "--db", str(db_path)])
+    assert ret == 0
+    out = capsys.readouterr().out
+    json_line = [line for line in out.splitlines() if line.startswith("[") or line.startswith("{")][0]
+    data = json.loads(json_line)
+    assert isinstance(data, list)
+    assert data[0]["path"].endswith("img.jpg")
+
+
 def test_cli_group_by(monkeypatch, tmp_path, capsys):
     img = Image.new("RGB", (5, 5))
     img_path = tmp_path / "img.jpg"


### PR DESCRIPTION
## Summary
- print metadata as JSON when no grouping options are passed
- add regression test for default CLI JSON output

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872bb409e74832981213d6089ded24e