### PR TITLE
Add group_by_face utility

### DIFF
--- a/photo_organizer/cluster.py
+++ b/photo_organizer/cluster.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Iterable
 
 import numpy as np
 from sklearn.cluster import DBSCAN
@@ -35,4 +35,25 @@ def cluster_faces(
     return metadata
 
 
-__all__ = ["cluster_faces"]
+def group_by_face(
+    metadata: Iterable[Dict[str, Any]]
+) -> Dict[int, List[Dict[str, Any]]]:
+    """Group metadata entries by face ``cluster_id``.
+
+    Each entry may be included in multiple groups if it contains faces from
+    different clusters. Entries without any faces labeled with a cluster ID are
+    ignored.
+    """
+
+    groups: Dict[int, List[Dict[str, Any]]] = {}
+    for entry in metadata:
+        seen: set[int] = set()
+        for face in entry.get("faces", []):
+            cid = face.get("cluster_id")
+            if isinstance(cid, int) and cid not in seen:
+                groups.setdefault(cid, []).append(entry)
+                seen.add(cid)
+    return groups
+
+
+__all__ = ["cluster_faces", "group_by_face"]

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,4 +1,4 @@
-from photo_organizer.cluster import cluster_faces
+from photo_organizer.cluster import cluster_faces, group_by_face
 
 
 def test_cluster_faces_assigns_ids():
@@ -24,3 +24,29 @@ def test_cluster_faces_assigns_ids():
         for face in entry["faces"]:
             assert "cluster_id" in face
             assert isinstance(face["cluster_id"], int)
+
+
+def test_group_by_face_groups_entries():
+    metadata = [
+        {
+            "path": "a.jpg",
+            "faces": [
+                {"cluster_id": 0},
+                {"cluster_id": 1},
+            ],
+        },
+        {
+            "path": "b.jpg",
+            "faces": [
+                {"cluster_id": 1},
+            ],
+        },
+    ]
+    groups = group_by_face(metadata)
+    assert set(groups.keys()) == {0, 1}
+    assert groups[0] == [metadata[0]]
+    assert groups[1] == [metadata[0], metadata[1]]
+
+
+def test_group_by_face_empty():
+    assert group_by_face([]) == {}


### PR DESCRIPTION
## Summary
- add `group_by_face` to cluster photos by face ID
- test grouping behaviour and empty case

## Testing
- `pycodestyle cli.py photo_organizer tests`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68730a5251b48329abab06c9b1ac74fc