### PR TITLE
Implement set_face_label style update

### DIFF
--- a/photo_organizer/db.py
+++ b/photo_organizer/db.py
@@ -12,13 +12,17 @@ CREATE TABLE IF NOT EXISTS photos (
     path TEXT UNIQUE,
     metadata TEXT
 );
+CREATE TABLE IF NOT EXISTS face_labels (
+    cluster_id INTEGER PRIMARY KEY,
+    name TEXT
+);
 """
 
 
 def init_db(path: str = "photo.db") -> sqlite3.Connection:
     """Initialize and return a database connection."""
     conn = sqlite3.connect(path)
-    conn.execute(SCHEMA)
+    conn.executescript(SCHEMA)
     conn.commit()
     return conn
 
@@ -35,4 +39,18 @@ def insert_metadata(
             )
 
 
-__all__ = ["init_db", "insert_metadata"]
+def set_face_label(
+    conn: sqlite3.Connection,
+    cluster_id: int,
+    name: str,
+) -> None:
+    """Associate a name with a face ``cluster_id`` in the database."""
+    with conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO face_labels(cluster_id, name) "
+            "VALUES (?, ?)",
+            (cluster_id, name),
+        )
+
+
+__all__ = ["init_db", "insert_metadata", "set_face_label"]


### PR DESCRIPTION
## Summary
- add schema for face_labels
- use `executescript` to init DB with multiple tables
- implement `set_face_label` with line wrapping
- ensure flake8 passes

## Testing
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873cbb5fb448329b2d81b70c8041780